### PR TITLE
#31, #29, Modify ncep ingest

### DIFF
--- a/geonode/NCEP/ncep_convert.sh
+++ b/geonode/NCEP/ncep_convert.sh
@@ -88,7 +88,7 @@ for (( i=0; i< $(($total_vars)); i++)); do
     # GDAL translate the NetCDF file into a GeoTIFF with EPSG:4326 projection called daily_air_temp.tif.
     printf "${RED}Translating the NetCDF file into a GeoTiff file...${NC}\n"
     gdal_translate -a_srs EPSG:4326 -of GTiff netCDF:"temporary.nc":${var_name[$i]} temporary.tif > /dev/null 2>&1
-    gdal_calc.py -A temporary.tif --overwrite --outfile=temporary.tif --calc="A-275.15"
+    gdal_calc.py -A temporary.tif --overwrite --outfile=temporary.tif --calc="A-273.15"
     gdalwarp -t_srs WGS84 temporary.tif $tif_name -wo SOURCE_EXTRA=100 --config CENTER_LONG 0 > /dev/null 2>&1
     printf "\n${GREEN}Successfully created ${RED}$tif_name ${NC}\n"
 

--- a/geonode/NCEP/ncep_convert.sh
+++ b/geonode/NCEP/ncep_convert.sh
@@ -139,7 +139,12 @@ gdal_translate -of Gtiff -b 1 $tmpsfc_file tmpsfc_wrong_center.tif > /dev/null 2
 gdalwarp -t_srs WGS84 tmpsfc_wrong_center.tif sea_surface_temperature_current_month_forecast_average.tif -wo SOURCE_EXTRA=100 --config CENTER_LONG 0 > /dev/null 2>&1
 
 printf "\n${RED}Importing new GeoTIFF into GeoNode...${NC}\n"
-`which python` $INSTALL_DIR/geonode/manage.py importlayers -o "sea_surface_temperature_current_month_forecast_average.tif" > /dev/null 2>&1
+`which python` \
+$INSTALL_DIR/geonode/manage.py \
+importlayers \
+-t "Projected Air Temperature, $proj_title" \
+-n "ncep_air_temperature_current_month_forecast_average" \
+-o "air_temperature_current_month_forecast_average.tif"
 
 printf "\n${RED}Translating the ${YELLOW}2m Air Temperature${RED} GRIB file into a colored GeoTIFF file...${NC}\n"
 gdal_translate -of Gtiff -b 1 $tmp2m_file tmp2m_wrong_center.tif > /dev/null 2>&1
@@ -149,19 +154,9 @@ printf "\n${RED}Importing new GeoTIFF into GeoNode...${NC}\n"
 `which python` \
 $INSTALL_DIR/geonode/manage.py \
 importlayers \
--t "Projected Air Temperature, $proj_title" \
--n "ncep_air_temperature_current_month_forecast_average" \
--o "air_temperature_current_month_forecast_average.tif" \
-> /dev/null 2>&1
-
-printf "\n${RED}Importing new GeoTIFF into GeoNode...${NC}\n"
-`which python` \
-$INSTALL_DIR/geonode/manage.py \
-importlayers \
 -t "Projected Sea Surface Temperature, $proj_title" \
 -n "ncep_sea_surface_temperature_current_month_forecast_average" \
--o "sea_surface_current_month_forecast_average.tif" \
-> /dev/null 2>&1
+-o "sea_surface_temperature_current_month_forecast_average.tif"
 
 rm -f $tmpsfc_file
 rm -f $tmp2m_file

--- a/geonode/NCEP/ncep_convert.sh
+++ b/geonode/NCEP/ncep_convert.sh
@@ -134,9 +134,9 @@ tmp2m_file="tmp2m.${req_date}0100.01.CFSv2.fcst.avrg.1x1.grb"
 wget "ftp://ftp.cpc.ncep.noaa.gov/NMME/realtime_anom/CFSv2/${req_date}0800/$tmpsfc_file" > /dev/null 2>&1
 wget "ftp://ftp.cpc.ncep.noaa.gov/NMME/realtime_anom/CFSv2/${req_date}0800/$tmp2m_file" > /dev/null 2>&1
 
-printf "\n${RED}Translating the ${YELLOW}Sea Surface Temperature${RED} GRIB file into a colored GeoTIFF file...${NC}\n"
-gdal_translate -of Gtiff -b 1 $tmpsfc_file tmpsfc_wrong_center.tif > /dev/null 2>&1
-gdalwarp -t_srs WGS84 tmpsfc_wrong_center.tif sea_surface_temperature_current_month_forecast_average.tif -wo SOURCE_EXTRA=100 --config CENTER_LONG 0 > /dev/null 2>&1
+printf "\n${RED}Translating the ${YELLOW}2m Air Temperature${RED} GRIB file into a colored GeoTIFF file...${NC}\n"
+gdal_translate -of Gtiff -b 1 $tmp2m_file tmp2m_wrong_center.tif > /dev/null 2>&1
+gdalwarp -t_srs WGS84 tmp2m_wrong_center.tif air_temperature_current_month_forecast_average.tif -wo SOURCE_EXTRA=100 --config CENTER_LONG 0 > /dev/null 2>&1
 
 printf "\n${RED}Importing new GeoTIFF into GeoNode...${NC}\n"
 `which python` \
@@ -146,9 +146,9 @@ importlayers \
 -n "ncep_air_temperature_current_month_forecast_average" \
 -o "air_temperature_current_month_forecast_average.tif"
 
-printf "\n${RED}Translating the ${YELLOW}2m Air Temperature${RED} GRIB file into a colored GeoTIFF file...${NC}\n"
-gdal_translate -of Gtiff -b 1 $tmp2m_file tmp2m_wrong_center.tif > /dev/null 2>&1
-gdalwarp -t_srs WGS84 tmp2m_wrong_center.tif air_temperature_current_month_forecast_average.tif -wo SOURCE_EXTRA=100 --config CENTER_LONG 0 > /dev/null 2>&1
+printf "\n${RED}Translating the ${YELLOW}Sea Surface Temperature${RED} GRIB file into a colored GeoTIFF file...${NC}\n"
+gdal_translate -of Gtiff -b 1 $tmpsfc_file tmpsfc_wrong_center.tif > /dev/null 2>&1
+gdalwarp -t_srs WGS84 tmpsfc_wrong_center.tif sea_surface_temperature_current_month_forecast_average.tif -wo SOURCE_EXTRA=100 --config CENTER_LONG 0 > /dev/null 2>&1
 
 printf "\n${RED}Importing new GeoTIFF into GeoNode...${NC}\n"
 `which python` \

--- a/geonode/NCEP/ncep_convert.sh
+++ b/geonode/NCEP/ncep_convert.sh
@@ -88,7 +88,7 @@ for (( i=0; i< $(($total_vars)); i++)); do
     # GDAL translate the NetCDF file into a GeoTIFF with EPSG:4326 projection called daily_air_temp.tif.
     printf "${RED}Translating the NetCDF file into a GeoTiff file...${NC}\n"
     gdal_translate -a_srs EPSG:4326 -of GTiff netCDF:"temporary.nc":${var_name[$i]} temporary.tif > /dev/null 2>&1
-    gdal_calc.py -A temporary.tif --overwrite --outfile=temporary.tif --calc="A+275.15"
+    gdal_calc.py -A temporary.tif --overwrite --outfile=temporary.tif --calc="A-275.15"
     gdalwarp -t_srs WGS84 temporary.tif $tif_name -wo SOURCE_EXTRA=100 --config CENTER_LONG 0 > /dev/null 2>&1
     printf "\n${GREEN}Successfully created ${RED}$tif_name ${NC}\n"
 


### PR DESCRIPTION
Convert to celsius and modify title of layer upon ingest.  Depends on [this pull request](https://github.com/ua-snap/geonode/pull/7/files) so Geocode must be checked out to that branch for this to work.

Removes colorizing step for the raster (`gdaldem`) and instead we use SLDs in GeoServer.  You can run this fresh and it should give a default greyscale, and use the recent DB dump to get the other stuff.

Not working yet: I don't think the dates are correct that are generated.  Also, this modifies the `layer` but not the `maplayer` title.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/vagrant-geonode/33)

<!-- Reviewable:end -->
