### PR TITLE
Additions for MapProxy and GDAL 1.11.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,21 @@ Once you complete the production setup instructions, it will not be easy to go b
 
 1. Visit `http://<public domain>/` in your browser. Everything should now be working.
 
+## Starting MapProxy with OSM Humanitarian layer
+
+1. MapProxy is installed as part of the initial install in Vagrant. To start this in Vagrant, run these commands:
+   ```
+   vagrant ssh
+   workon geonode
+   mapproxy-util serve-develop -b 0.0.0.0:8888 $INSTALL_DIR/mapventure-mapproxy/mapproxy.yaml
+   ```
+
+1. With MapProxy running, you can view the OSM Humanitarian layer at:
+   
+   ```
+   http://localhost:8888/demo/?tms_layer=osm&format=png&srs=EPSG%3A3857
+   ```
+
 ## Creating and Restoring from Backups
 
 This section can be used to either create a backup of GeoNode and GeoServer from a production or development environment and restoring this backup on either a development or production environment.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,7 @@ Vagrant.configure(2) do |config|
   config.vm.network "forwarded_port", guest: 80, host: 8888
   config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.network "forwarded_port", guest: 8080, host: 8080
+  config.vm.network "forwarded_port", guest: 8888, host: 8888
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.

--- a/geonode/.gitignore
+++ b/geonode/.gitignore
@@ -11,3 +11,4 @@ NCEP/*
 !NCEP/ncep_convert.sh
 !NCEP/temp_color_k.txt
 !NCEP/temp_color_c.txt
+!mapventure-mapproxy.yaml

--- a/geonode/mapventure-mapproxy.yaml
+++ b/geonode/mapventure-mapproxy.yaml
@@ -37,6 +37,6 @@ sources:
 
 grids:
     webmercator:
-        base: GLOBAL_WEBMERCATOR                        
-    
-globals: 
+        base: GLOBAL_WEBMERCATOR
+
+globals:

--- a/geonode/mapventure-mapproxy.yaml
+++ b/geonode/mapventure-mapproxy.yaml
@@ -1,0 +1,42 @@
+services:
+  demo:
+  tms:
+    use_grid_names: true
+    # origin for /tiles service
+    origin: 'nw'
+  kml:
+      use_grid_names: true
+  wmts:
+  wms:
+    srs: ['EPSG:3338']
+    md:
+      title: MapProxy WMS Proxy
+      abstract: This is a minimal MapProxy example.
+
+layers:
+  - name: osm
+    title: Omniscale OSM WMS - osm.omniscale.net
+    sources: [osm_cache]
+
+caches:
+  osm_cache:
+    grids: [webmercator]
+    sources: [osm_tms]
+
+sources:
+  osm_wms:
+    type: wms
+    req:
+      # use of this source is only permitted for testing
+      url: http://osm.omniscale.net/proxy/service?
+      layers: osm
+  osm_tms:
+    type: tile
+    url: http://b.tile.openstreetmap.fr/hot/%(z)s/%(x)s/%(y)s.png
+    grid: GLOBAL_WEBMERCATOR
+
+grids:
+    webmercator:
+        base: GLOBAL_WEBMERCATOR                        
+    
+globals: 


### PR DESCRIPTION
Modification to automation script to install MapProxy and install the OSM Humanitarian tile layer configuration for MapProxy. 

Also, installs GDAL 1.11.2 along with the GeoNode 2.4.x branch from our fork of GeoNode.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/vagrant-geonode/41)

<!-- Reviewable:end -->
